### PR TITLE
chore: update fp-ts to 0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "newtype-ts",
   "version": "0.0.1",
   "description": "Implementation of newtypes in TypeScript",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
@@ -26,7 +28,7 @@
   },
   "homepage": "https://github.com/gcanti/newtype-ts",
   "dependencies": {
-    "fp-ts": "^0.5.1",
+    "fp-ts": "^0.5.4",
     "monocle-ts": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi Giulio

I made the mistake of updating some of our projects to fp-ts 0.5.4, and now I'm getting the dreaded "objects have the same name but are different" TS errors. This is because I'm using other libs of yours like this one, so npm is loading two copies of fp-ts. Any chance you can cut a new version that ups the dependency to 0.5.4?

I'll submit PRs for the others too.