### PR TITLE
readme: fix integer detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import { Newtype, prism } from 'newtype-ts'
 
 interface Integer extends Newtype<{ readonly Integer: unique symbol }, number> {}
 
-const isInteger = (n: number) => n % 1 === 0
+const isInteger = (n: number) => Number.isInteger(n);
 
 // prismInteger: Prism<number, Integer>
 const prismInteger = prism<Integer>(isInteger)


### PR DESCRIPTION
Hello,

Thanks for this great library :) I was playing around with the examples I encountered something I was not expecting:

```ts 
interface Integer extends Newtype<{ readonly Integer: unique symbol }, number> {}

const isInteger = (n: number) => n % 1 === 0;

// prismInteger: Prism<number, Integer>
const prismInteger = prism<Integer>(isInteger);

const add1 = (n: Integer) => prismInteger.reverseGet(n) + 1;

prismInteger.getOption(undefined).map(add1); // None
prismInteger.getOption(null).map(add1); // Some(1)
```

I would have expected the `null` example to give me `None` as for the `undefined` one. 

Seems like it's because `null % 1 === 0`. I fixed it by using `Number.isInteger` function.